### PR TITLE
Repeated requests just before period trigger the rate limit

### DIFF
--- a/spec/simple_api_spec.rb
+++ b/spec/simple_api_spec.rb
@@ -23,6 +23,11 @@ describe "ThrottleHelper" do
       get('/wrong-configuration') do
         "step on it"
       end
+
+      throttle period: 5.seconds, limit: 3
+      get('/really-short-throttle') do
+        "step on it"
+      end
     end
   end
 
@@ -66,6 +71,17 @@ describe "ThrottleHelper" do
       expect(last_response.status).to eq(200)
     end
 
+  end
+
+  describe "requests just below the period" do
+    it "do not get throttled by the rate limit" do
+      4.times do
+        get "/throttle"
+        sleep 4
+      end
+
+      expect(last_response.status).to eq(200)
+    end
   end
 
   describe 'Redis down' do


### PR DESCRIPTION
Hi,

At the moment, the user counter expiry is reset every time a successful request is made. This means that if a request is repeatedly made just before the timeout expires, the rate limit can be hit without actually exceeding it.

For example, if an endpoint has a limit of 3 requests every minute, and I make four requests, each 59 seconds apart, then I will hit the rate limiter despite making requests at just under 1/3 of the rate limit.

I don't have time to contribute a fix right at the moment, though (sorry) - in the interim I thought I'd add a failing test to work with.

Cheers,
Simon
