### PR TITLE
Use HTTP 429 code instead of 403 according to the RFC6585

### DIFF
--- a/lib/grape/middleware/throttle_middleware.rb
+++ b/lib/grape/middleware/throttle_middleware.rb
@@ -33,7 +33,7 @@ module Grape
           redis.ping
           current = redis.get(rate_key).to_i
           if !current.nil? && current >= limit
-            endpoint.error!("too many requests, please try again later", 403)
+            endpoint.error!("too many requests, please try again later", 429)
           else
             redis.multi do
               # Set the value of the key to COUNTER_START if the key does not already exist and

--- a/spec/simple_api_spec.rb
+++ b/spec/simple_api_spec.rb
@@ -43,7 +43,7 @@ describe "ThrottleHelper" do
 
     it "is throttled beyond the rate limit" do
       4.times { get "/throttle" }
-      expect(last_response.status).to eq(403)
+      expect(last_response.status).to eq(429)
     end
 
     describe "with custom period" do
@@ -55,7 +55,7 @@ describe "ThrottleHelper" do
 
       it "is throttled beyond the rate limit" do
         4.times { get "/throttle-custom-period" }
-        expect(last_response.status).to eq(403)
+        expect(last_response.status).to eq(429)
       end
 
     end


### PR DESCRIPTION
Hi there,

I think that it should return HTTP 429 code instead of 403 when user exceeded rate limit. HTTP 403 stands for Forbidden while HTTP 429 for Too Many Requests. Take a look at [RFC6585](https://tools.ietf.org/html/rfc6585).
